### PR TITLE
Support plugins for s390x linux arch

### DIFF
--- a/pipelinesScripts/pluginRelease.sh
+++ b/pipelinesScripts/pluginRelease.sh
@@ -117,6 +117,7 @@ downloadJfrogCli
 # Keep 'linux-386' first to prevent unnecessary uploads in case the built version doesn't match the provided one.
 buildAndUpload 'linux-386' 'linux' '386' ''
 buildAndUpload 'linux-amd64' 'linux' 'amd64' ''
+buildAndUpload 'linux-s390x' 'linux' 's390x' ''
 buildAndUpload 'linux-arm64' 'linux' 'arm64' ''
 buildAndUpload 'linux-arm' 'linux' 'arm' ''
 buildAndUpload 'mac-386' 'darwin' 'amd64' ''


### PR DESCRIPTION
Build are release plugins for the **s390x** Linux architecture, which has been recently added to JFrog CLI's release as well.