### PR TITLE
Update plugins versions

### DIFF
--- a/plugins/build-deps-info.yml
+++ b/plugins/build-deps-info.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: build-deps-info
-version: v1.2.0
+version: v1.2.1
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - Or-Gabay

--- a/plugins/build-report.yml
+++ b/plugins/build-report.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: build-report
-version: v1.0.0
+version: v1.0.1
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - RobiNino

--- a/plugins/file-spec-gen.yml
+++ b/plugins/file-spec-gen.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: file-spec-gen
-version: v1.0.0
+version: v1.0.1
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - barbelity

--- a/plugins/rt-cleanup.yml
+++ b/plugins/rt-cleanup.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: rt-cleanup
-version: v1.0.1
+version: v1.0.2
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - talarian1

--- a/plugins/rt-fs.yml
+++ b/plugins/rt-fs.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: rt-fs
-version: v1.1.1
+version: v1.1.2
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - yahavi


### PR DESCRIPTION
Related to https://github.com/jfrog/jfrog-cli-plugins/pull/54

Update build-deps-info, build-report, file-spec-gen, rt-cleanup, and rt-fs to their next patch version.
