### PR TITLE
Update GOPROXY env var in piplines.yml

### DIFF
--- a/pipelines.yml
+++ b/pipelines.yml
@@ -116,7 +116,7 @@ pipelines:
           onExecute:
             - git clone https://github.com/jfrog/jfrog-cli-plugins.git && jfrogCliPluginsPath=`pwd`/jfrog-cli-plugins
             - git clone https://github.com/jfrog/jfrog-cli-plugins-reg.git && cd jfrog-cli-plugins-reg/pipelinesScripts/validator
-            - env -i PATH=$PATH GOPROXY=direct issue_token=$int_JFrog_CLI_Plugins_Issure_token HOME=$HOME PWD=$PWD JAVA_HOME=$JAVA_HOME GRADLE_HOME=$GRADLE_HOME MAVEN_HOME=$MAVEN_HOME go run validator.go upgradejfrogplugins $jfrogCliPluginsPath
+            - env -i PATH=$PATH GOPROXY=https://goproxy.io,direct issue_token=$int_JFrog_CLI_Plugins_Issure_token HOME=$HOME PWD=$PWD JAVA_HOME=$JAVA_HOME GRADLE_HOME=$GRADLE_HOME MAVEN_HOME=$MAVEN_HOME go run validator.go upgradejfrogplugins $jfrogCliPluginsPath
             - cd $jfrogCliPluginsPath
             # Override origin.
             - git remote set-url origin https://github.com/jfrog/jfrog-cli-plugins.git && git fetch origin main && git checkout main


### PR DESCRIPTION
Following this [PR](https://github.com/jfrog/jfrog-cli-plugins-reg/commit/f828b83664378a37b33944ae5dd9d4d2e770cbdc), GOPROXY=direct was added. Afterward, the automation build fails for:
go: gopkg.in/yaml.v2@v2.3.0: reading gopkg.in/yaml.v2/go.mod at revision v2.3.0: unknown revision v2.3.0
