### PR TITLE
Add /v2  suffix to jfrog-cli-core dependency

### DIFF
--- a/pipelinesScripts/validator/dependency/dependency.go
+++ b/pipelinesScripts/validator/dependency/dependency.go
@@ -11,12 +11,12 @@ import (
 
 // This struct represents a go dependency in the go.mod file.
 type Details struct {
-	Path                    string
-	Version                 string
+	Path    string
+	Version string
 }
 
 type JFrogDependencyDetails struct {
-	Name                    string
+	Name                   string
 	MajorVersionModulePath string
 }
 


### PR DESCRIPTION
Upgrading jfrog-cli-core to the latest version to each plugin fails. It runs `go get github.com/jfrog/jfrog-cli-core@vx.x.x` with the latest v2 version but missing the '/v2' suffix.