### PR TITLE
Fix 'jf rt u' command in pluginUpload.sh

### DIFF
--- a/pipelinesScripts/pluginUpload.sh
+++ b/pipelinesScripts/pluginUpload.sh
@@ -74,7 +74,7 @@ buildAndUpload () {
 
   destPath="$JFROG_CLI_PLUGINS_RT_REGISTRY_REPO/$JFROG_CLI_PLUGIN_PLUGIN_NAME/$JFROG_CLI_PLUGIN_VERSION/$pkg/$exeName"
   echo "Uploading $exeName to $JFROG_CLI_PLUGINS_RT_REGISTRY_URL/$destPath ..."
-  jf rt u ./"$exeNamev" "$destPath"
+  jf rt u "./$exeNamev" "$destPath"
 }
 
 # Verify uniqueness of the requested plugin's version


### PR DESCRIPTION
Fix for the below issue, while publishing a plugin - 

![image](https://user-images.githubusercontent.com/7830056/149330224-89f32329-62ba-4311-9c55-23e15a1be8ca.png)
