### PR TITLE
README design improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,32 +3,108 @@
 **JFrog CLI Plugins** allow enhancing the functionality of [JFrog CLI](https://www.jfrog.com/confluence/display/CLI/JFrog+CLI) to meet the specific user and organization needs. The source code of a plugin is maintained as an open source Go project on GitHub. All public plugins are registered in **JFrog CLI's Plugins Registry**. The Registry is hosted in this GitHub repository. The [plugins](plugins) directory includes a descriptor file for each plugin included in the Registry. 
 
 ## Installing a plugin 
-After a plugin is included in this Registry, it becomes available for installation using JFrog CLI. JFrog CLI version 1.41.1 or above is required. To install a plugin included in this registry, run the following JFrog CLI command -  `jfrog plugin install plugin-name`. 
+After a plugin is included in this Registry, it becomes available for installation using JFrog CLI. JFrog CLI version 1.41.1 or above is required. To install a plugin included in this registry, run the following JFrog CLI command -  `jf plugin install plugin-name`. 
 
-## The list of available plugins
-* [build-deps-info](https://github.com/jfrog/jfrog-cli-plugins/tree/main/build-deps-info) - The build-deps-info plugin prints the dependencies' details of a specific build, which has been previously published to Artifactory.
+## Available plugins
 
-* [build-report](https://github.com/jfrog/jfrog-cli-plugins/tree/main/build-report) - This JFrog CLI plugin prints a report of a published build info in Artifactory, or the diff between two builds.
-
-* [cve-impact-check](https://github.com/rdar-lab/cve-impact-check) - This plugin allows checking via Xray if there are any impacted artifacts on a specific env/jfrog platform. It requires the artifacts to be already indexed by Xray.
-
-* [file-spec-gen](https://github.com/jfrog/jfrog-cli-plugins/tree/main/file-spec-gen) - This plugin provides an easy way for generating file-specs json.
-
-* [JCheck](https://github.com/rdar-lab/JCheck) - A Micro-UTP, plug-able sanity checker for any on-prem JFrog platform instance.
-
-* [jfrog-yocto](https://github.com/rdar-lab/jfrog-cli-yocto-plugin) - This plugin allows integrating Yocto builds with the JFrog Platform.
-
-* [live-logs](https://github.com/jfrog/live-logs) - The JFrog Platform includes an integrated Live Logs plugin, which allows customers to get the JFrog product logs (Artifactory, Xray, Mission Control, Distribution, and Pipelines) using the JFrog CLI Plugin. The plugin also provides the ability to cat and tail -f any log on any product node.
-
-* [metrics-viewer](https://github.com/eldada/metrics-viewer/tree/master) - A plugin or standalone binary to show open-metrics formatted data in a terminal based graph.
-
-* [repostats](https://github.com/chanti529/repostats) - This plugin can help find out the most popularly downlaoded artifacts in a given repository, Artifacts that are consuming the most space in a given repository with various levels of customization available. Results obtained can also be sorted and filtered.
-
-* [rm-empty](https://github.com/jfrog/jfrog-cli-plugins/tree/main/rm-empty) - This plugin deletes all the empty folders under a specific path in Artifactory.
-
-* [rt-cleanup](https://github.com/jfrog/jfrog-cli-plugins/tree/main/rt-cleanup) - This plugin is a simple Artifactory cleanup plugin. It can be used to delete all artifacts that have not been downloaded for the past n time units (both can be configured) from a given repository.
-
-* [rt-fs](https://github.com/jfrog/jfrog-cli-plugins/tree/main/rt-fs) - This plugin executes file system commands in Artifactory. It is designed to mimic the functionality of the Linux/Unix 'ls' and 'cat' commands.
+<table>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/jfrog/jfrog-cli-plugins/tree/main/build-deps-info">build-deps-info</a>
+        </td>
+        <td>
+            The build-deps-info plugin prints the dependencies' details of a specific build, which has been previously published to Artifactory.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/jfrog/jfrog-cli-plugins/tree/main/build-report">build-report</a>
+        </td>
+        <td>
+            This JFrog CLI plugin prints a report of a published build info in Artifactory, or the diff between two builds.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/rdar-lab/cve-impact-check">cve-impact-check</a>
+        </td>
+        <td>
+            This plugin allows checking via Xray if there are any impacted artifacts on a specific env/jfrog platform. It requires the artifacts to be already indexed by Xray.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/jfrog/jfrog-cli-plugins/tree/main/file-spec-gen">file-spec-gen</a>
+        </td>
+        <td>
+            This plugin provides an easy way for generating file-specs json.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/rdar-lab/JCheck">JCheck</a>
+        </td>
+        <td>
+            A Micro-UTP, plug-able sanity checker for any on-prem JFrog platform instance.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/rdar-lab/jfrog-cli-yocto-plugin">jfrog-yocto</a>
+        </td>
+        <td>
+            This plugin allows integrating Yocto builds with the JFrog Platform.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/jfrog/live-logs">live-logs</a>
+        </td>
+        <td>
+            The JFrog Platform includes an integrated Live Logs plugin, which allows customers to get the JFrog product logs (Artifactory, Xray, Mission Control, Distribution, and Pipelines) using the JFrog CLI Plugin. The plugin also provides the ability to cat and tail -f any log on any product node.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/eldada/metrics-viewer/tree/master">metrics-viewer</a>
+        </td>
+        <td>
+            A plugin or standalone binary to show open-metrics formatted data in a terminal based graph.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/chanti529/repostats">repostats</a>
+        </td>
+        <td>
+            This plugin can help find out the most popularly downlaoded artifacts in a given repository, Artifacts that are consuming the most space in a given repository with various levels of customization available. Results obtained can also be sorted and filtered.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/jfrog/jfrog-cli-plugins/tree/main/rm-empty">rm-empty</a>
+        </td>
+        <td>
+            This plugin deletes all the empty folders under a specific path in Artifactory.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/jfrog/jfrog-cli-plugins/tree/main/rt-cleanup">rt-cleanup</a>
+        </td>
+        <td>
+            This plugin is a simple Artifactory cleanup plugin. It can be used to delete all artifacts that have not been downloaded for the past n time units (both can be configured) from a given repository.
+        </td>
+    </tr>
+    <tr>
+        <td width="20%">
+            <a href="https://github.com/jfrog/jfrog-cli-plugins/tree/main/rt-fs">rt-fs</a>
+        </td>
+        <td>
+            This plugin executes file system commands in Artifactory. It is designed to mimic the functionality of the Linux/Unix 'ls' and 'cat' commands.
+        </td>
+    </tr>
+</table>
 
 ## Developing and publishing plugins
 We encourage you, as developers, to create plugins and share them publicly with the rest of the community. Read the [JFrog CLI Plugins Developer Guide](https://github.com/jfrog/jfrog-cli/blob/master/guides/jfrog-cli-plugins-developer-guide.md) for information about developing and publishing JFrog CLI Plugins.


### PR DESCRIPTION
* Replaced list with table in README
* Replaced 'jfrog' with 'jf' in installation command
* Shortened one of the titles

See new design - https://github.com/eyalbe4/jfrog-cli-plugins-reg/blob/readme-table/README.md