### PR TITLE
Bug fix - Plugins fail to be published

### DIFF
--- a/pipelinesScripts/publishPlugin.sh
+++ b/pipelinesScripts/publishPlugin.sh
@@ -2,7 +2,7 @@
 
 # Publish plugin -build, verify unique version and upload for all architectures.
 publishPlugin () {
-  jf plugins p "$JFROG_CLI_PLUGIN_PLUGIN_NAME" "$JFROG_CLI_PLUGIN_VERSION"
+  jf plugin p "$JFROG_CLI_PLUGIN_PLUGIN_NAME" "$JFROG_CLI_PLUGIN_VERSION"
 }
 
 publishPlugin


### PR DESCRIPTION
Fixed mis-spelled jfrog-cli command, which fails publishing new plugins to the registry.