### PR TITLE
Plugins release pipeline fix - Make the release bundle name unique

### DIFF
--- a/pipelines.yml
+++ b/pipelines.yml
@@ -97,8 +97,8 @@ pipelines:
               jf plugin p "$JFROG_CLI_PLUGIN_PLUGIN_NAME" "$JFROG_CLI_PLUGIN_VERSION"
             # Distribute Plugin to releases.
             - options="--url=$int_entplus_deployer_url/distribution --user=$int_entplus_deployer_user --password=$int_entplus_deployer_apikey"
-            - jf ds rbc "cli-plugins" $JFROG_CLI_PLUGIN_VERSION --spec="plugin-rbc-spec.json" --spec-vars="NAME=$JFROG_CLI_PLUGIN_PLUGIN_NAME;VERSION=$JFROG_CLI_PLUGIN_VERSION" --sign $options
-            - jf ds rbd "cli-plugins" $JFROG_CLI_PLUGIN_VERSION --site=releases.jfrog.io --sync $options
+            - jf ds rbc "cli-plugins-$JFROG_CLI_PLUGIN_PLUGIN_NAME" $JFROG_CLI_PLUGIN_VERSION --spec="plugin-rbc-spec.json" --spec-vars="NAME=$JFROG_CLI_PLUGIN_PLUGIN_NAME;VERSION=$JFROG_CLI_PLUGIN_VERSION" --sign $options
+            - jf ds rbd "cli-plugins-$JFROG_CLI_PLUGIN_PLUGIN_NAME" $JFROG_CLI_PLUGIN_VERSION --site=releases.jfrog.io --sync $options
             # Copy version to 'latest' directory in releases.jfrog.io
             - jf rt cp "jfrog-cli-plugins/$JFROG_CLI_PLUGIN_PLUGIN_NAME/$JFROG_CLI_PLUGIN_VERSION/(*)" "jfrog-cli-plugins/$JFROG_CLI_PLUGIN_PLUGIN_NAME/latest/{1}" --url=https://releases.jfrog.io/artifactory/ --access-token=$int_releases_jfrog_io_deployer_access_token
           onComplete:


### PR DESCRIPTION
Making the release bundle name unique, by adding the published plugin name to it, should resolve the following issue during the release of a plugin.
<img width="959" alt="image" src="https://user-images.githubusercontent.com/7830056/163848425-fdaa0f8b-9565-4938-8192-a6b6d29a22f8.png">
