### PR TITLE
Jfrog-core-cli releases v1 do not auto-upgrade plugins

### DIFF
--- a/pipelinesScripts/validator/dependency/dependency.go
+++ b/pipelinesScripts/validator/dependency/dependency.go
@@ -45,6 +45,15 @@ func GetJfrogLatest() (dependencies []Details, err error) {
 	return
 }
 
+func IsCoreVersionOneReleased(dependencies []Details) bool{
+	for _, dep := range dependencies {
+		if strings.Contains(dep.Path,"jfrog-cli-core") {
+			return strings.HasPrefix(dep.Version,"v1.")
+		}
+	}
+	return false
+}
+
 func Upgrade(projectPath string, dependencies []Details) (err error) {
 	for _, dependency := range dependencies {
 		if err = utils.UpdateGoDependency(projectPath, dependency.Path, dependency.Version); err != nil {

--- a/pipelinesScripts/validator/dependency/dependency.go
+++ b/pipelinesScripts/validator/dependency/dependency.go
@@ -45,10 +45,11 @@ func GetJfrogLatest() (dependencies []Details, err error) {
 	return
 }
 
-func IsCoreVersionOneReleased(dependencies []Details) bool{
+// Return true if dependencies contains jfrog-cli-core v1
+func IsCoreV1DepIncluded(dependencies []Details) bool {
 	for _, dep := range dependencies {
-		if strings.Contains(dep.Path,"jfrog-cli-core") {
-			return strings.HasPrefix(dep.Version,"v1.")
+		if strings.Contains(dep.Path, "jfrog-cli-core") {
+			return strings.HasPrefix(dep.Version, "v1.")
 		}
 	}
 	return false

--- a/pipelinesScripts/validator/dependency/dependency_test.go
+++ b/pipelinesScripts/validator/dependency/dependency_test.go
@@ -36,7 +36,7 @@ func TestUpgrade(t *testing.T) {
 	assert.NoError(t, fileutils.CopyFile(tempDirPath, filepath.Join(wd, "testdata", "gomod")))
 	assert.NoError(t, fileutils.MoveFile(filepath.Join(tempDirPath, "gomod"), filepath.Join(tempDirPath, "go.mod")))
 	assert.NoError(t, Upgrade(tempDirPath, []Details{{Path: "github.com/jfrog/jfrog-cli-core", Version: "v1.2.6"}, {Path: "github.com/jfrog/jfrog-client-go", Version: "v0.18.0"}}))
-	fileDetails, err := fileutils.GetFileDetails(filepath.Join(tempDirPath, "go.mod"))
+	fileDetails, err := fileutils.GetFileDetails(filepath.Join(tempDirPath, "go.mod"), false)
 	assert.NoError(t, err)
 	assert.Equal(t, fileDetails.Checksum.Md5, "393573bda8c6f6a10dee023785165ee1")
 }

--- a/pipelinesScripts/validator/dependency/dependency_test.go
+++ b/pipelinesScripts/validator/dependency/dependency_test.go
@@ -36,7 +36,7 @@ func TestUpgrade(t *testing.T) {
 	assert.NoError(t, fileutils.CopyFile(tempDirPath, filepath.Join(wd, "testdata", "gomod")))
 	assert.NoError(t, fileutils.MoveFile(filepath.Join(tempDirPath, "gomod"), filepath.Join(tempDirPath, "go.mod")))
 	assert.NoError(t, Upgrade(tempDirPath, []Details{{Path: "github.com/jfrog/jfrog-cli-core", Version: "v1.2.6"}, {Path: "github.com/jfrog/jfrog-client-go", Version: "v0.18.0"}}))
-	fileDetails, err := fileutils.GetFileDetails(filepath.Join(tempDirPath, "go.mod"), false)
+	fileDetails, err := fileutils.GetFileDetails(filepath.Join(tempDirPath, "go.mod"), true)
 	assert.NoError(t, err)
 	assert.Equal(t, fileDetails.Checksum.Md5, "393573bda8c6f6a10dee023785165ee1")
 }

--- a/pipelinesScripts/validator/dependency/dependency_test.go
+++ b/pipelinesScripts/validator/dependency/dependency_test.go
@@ -40,3 +40,10 @@ func TestUpgrade(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, fileDetails.Checksum.Md5, "393573bda8c6f6a10dee023785165ee1")
 }
+
+func TestIsCoreVersionOneReleased(t *testing.T) {
+	dependency := []Details{{Path: "github.com/jfrog/jfrog-cli-core/v2", Version: "v1.11.4"}}
+	assert.True(t,IsCoreVersionOneReleased(dependency))
+	dependency = []Details{{Path: "github.com/jfrog/jfrog-cli-core/v2", Version: "v2.11.4"}}
+	assert.False(t,IsCoreVersionOneReleased(dependency))
+}

--- a/pipelinesScripts/validator/dependency/dependency_test.go
+++ b/pipelinesScripts/validator/dependency/dependency_test.go
@@ -41,9 +41,9 @@ func TestUpgrade(t *testing.T) {
 	assert.Equal(t, fileDetails.Checksum.Md5, "393573bda8c6f6a10dee023785165ee1")
 }
 
-func TestIsCoreVersionOneReleased(t *testing.T) {
+func TestIsCoreV1DepIncluded(t *testing.T) {
 	dependency := []Details{{Path: "github.com/jfrog/jfrog-cli-core/v2", Version: "v1.11.4"}}
-	assert.True(t,IsCoreVersionOneReleased(dependency))
+	assert.True(t, IsCoreV1DepIncluded(dependency))
 	dependency = []Details{{Path: "github.com/jfrog/jfrog-cli-core/v2", Version: "v2.11.4"}}
-	assert.False(t,IsCoreVersionOneReleased(dependency))
+	assert.False(t, IsCoreV1DepIncluded(dependency))
 }

--- a/pipelinesScripts/validator/go.sum
+++ b/pipelinesScripts/validator/go.sum
@@ -74,7 +74,6 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pipelinesScripts/validator/utils/utils.go
+++ b/pipelinesScripts/validator/utils/utils.go
@@ -20,6 +20,7 @@ const (
 	Tests               ValidationType = "tests"
 	UpgradeJfrogPlugins ValidationType = "upgradejfrogplugins"
 	PluginDescriptorDir string         = "plugins"
+	rootDirName                        = "jfrog-cli-plugins-reg"
 )
 
 func PrintUsageAndExit() {
@@ -43,15 +44,14 @@ func RunCommand(dir string, getOutput bool, name string, args ...string) (output
 
 // Gets the root directory of `jfrog-cli-plugins-reg` project, where the plugins descriptors directory located.
 func getRootPath() (string, error) {
-	rootPath := filepath.Join("..", "..")
-	absRootPath, err := filepath.Abs(rootPath)
+	pwd, err := os.Getwd()
 	if err != nil {
-		return "", errors.New("Failed to convert path to Abs path for " + rootPath + ". Error:" + err.Error())
+		return "", err
 	}
-	if _, err := os.Stat(filepath.Join(absRootPath, "plugins")); os.IsNotExist(err) {
-		return "", errors.New("Failed to find 'plugin' folder in:" + rootPath + ". Error:" + err.Error())
+	if !strings.Contains(pwd, rootDirName) {
+		return "", errors.New("Failed to find 'plugin' folder in:" + pwd + ".")
 	}
-	return absRootPath, nil
+	return strings.Split(pwd, rootDirName)[0] + rootDirName, nil
 }
 
 func GetPluginsDescriptors() ([]*PluginDescriptor, error) {

--- a/pipelinesScripts/validator/validator.go
+++ b/pipelinesScripts/validator/validator.go
@@ -132,8 +132,8 @@ func upgradeJfrogPlugins() error {
 	if err != nil {
 		return err
 	}
-	if dependency.IsCoreVersionOneReleased(depToUpgrade){
-		fmt.Println("The JFrog-cli-core release 1.x.x was encountered. Skipping the upgrade process...")
+	if dependency.IsCoreV1DepIncluded(depToUpgrade) {
+		fmt.Println("The JFrog-cli-core release 1.x.x was detected. Skipping the upgrade process...")
 		return nil
 	}
 	fmt.Println("Starting to upgrade JFrog plugins...")

--- a/pipelinesScripts/validator/validator.go
+++ b/pipelinesScripts/validator/validator.go
@@ -132,6 +132,10 @@ func upgradeJfrogPlugins() error {
 	if err != nil {
 		return err
 	}
+	if dependency.IsCoreVersionOneReleased(depToUpgrade){
+		fmt.Println("The JFrog-cli-core release 1.x.x was encountered. Skipping the upgrade process...")
+		return nil
+	}
 	fmt.Println("Starting to upgrade JFrog plugins...")
 	failedPlugins, err := doUpgrade(descriptors, depToUpgrade, cliPluginPath)
 	if err != nil {


### PR DESCRIPTION
Every release of Jfrog-CLI-Core runs the auto-upgrade script which upgrades all JFrog plugins.
V1 releases should be skipped as the plugins are compatible with V2 only