### PR TITLE
Changing jfrog-cli-plugins versions

### DIFF
--- a/plugins/build-deps-info.yml
+++ b/plugins/build-deps-info.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: build-deps-info
-version: v1.2.3
+version: v1.2.4
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - Or-Gabay

--- a/plugins/build-report.yml
+++ b/plugins/build-report.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: build-report
-version: v1.0.3
+version: v1.0.4
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - RobiNino

--- a/plugins/file-spec-gen.yml
+++ b/plugins/file-spec-gen.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: file-spec-gen
-version: v1.0.4
+version: v1.0.5
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - barbelity

--- a/plugins/rm-empty.yml
+++ b/plugins/rm-empty.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: rm-empty
-version: v1.0.2
+version: v1.0.3
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - eyalbe4

--- a/plugins/rt-cleanup.yml
+++ b/plugins/rt-cleanup.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: rt-cleanup
-version: v1.1.1
+version: v1.1.2
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - talarian1

--- a/plugins/rt-fs.yml
+++ b/plugins/rt-fs.yml
@@ -1,6 +1,6 @@
 # mandatory:
 pluginName: rt-fs
-version: v1.1.4
+version: v1.1.5
 repository: https://github.com/jfrog/jfrog-cli-plugins
 maintainers:
   - yahavi


### PR DESCRIPTION
Change jfrog-cli-versions in order to release them - added support of mac-arm64 in jfrog-cli:
https://github.com/jfrog/jfrog-cli/pull/1618